### PR TITLE
Avoid CURLOPT_FOLLOWLOCATION w/ restricted basedir

### DIFF
--- a/php/src/mollie/api.php
+++ b/php/src/mollie/api.php
@@ -237,7 +237,6 @@ abstract class Mollie_API
 
 		curl_setopt($ch, CURLOPT_HEADER, false);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 20);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, self::STRICT_SSL);
 		curl_setopt($ch, CURLOPT_ENCODING, ''); // Signal that we support gzip


### PR DESCRIPTION
When the `open_basedir` restriction is in effect, the `CURLOPT_FOLLOWLOCATION` option cannot be set. This line would previously generate a warning with `open_`basedir` restrictions.