### PR TITLE
Redirect URL not working

### DIFF
--- a/php/src/mollie/reseller.php
+++ b/php/src/mollie/reseller.php
@@ -325,7 +325,7 @@ class Mollie_Reseller extends Mollie_API
     {
         $params = [
             "partner_id_customer" => $partner_id_customer,
-            "redirect_URL" => $redirect_url
+            "redirect_url" => $redirect_url
         ];
 
         return $this->performRequest(


### PR DESCRIPTION
This parameter was wrongly named in the Mollie reseller documentation. This has been fixed in the documentation today, but this needs to be fixed in the reseller.php as well.